### PR TITLE
Fix diff parse logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themoin/diff-calculator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/themoin/diff-calculator.git"

--- a/src/lib/parseGitDiff.ts
+++ b/src/lib/parseGitDiff.ts
@@ -120,8 +120,14 @@ async function parseFileHeader(
             fileDiffType = "D";
             break;
           case "i":
-            // dissimilarity index <number>
-            await scanner.scan();
+            switch (line[2]) {
+              case "f":
+                // next diff, so break
+                break loop;
+              default:
+                // dissimilarity index <number>
+                await scanner.scan();
+            }
         }
         break;
       case "c":


### PR DESCRIPTION
`dissimilarity index` and `diff --git` case can be overlapped in current logic, so handle two cases differently.